### PR TITLE
docs: define alpha exit criteria for peering and probing

### DIFF
--- a/content/docs/peering/_index.md
+++ b/content/docs/peering/_index.md
@@ -13,7 +13,13 @@ PeerLab is currently in **alpha**. Core functionality is operational, and docume
 
 **Alpha Exit Criteria**
 
-To be defined.
+Before PeerLab exits alpha, we want every BGP session to be a safe, well-behaved IXP participant:
+
+- **BGP discipline** — enforce max-prefix / import limits, announcement rate-limiting (MRAI, aligned with the common norm of <= 10 announcements per hour), and route-flap damping on all sessions.
+- **RPKI enforcement** — inline ROV (`roa_check`) on routes imported from the IXP.
+- **Reload safety** — validate generated BIRD configuration before applying it.
+
+Origin-ASN and leased-prefix ownership filtering, and per-lease RPKI ROA management, are already in place.
 
 If you are interested in being an early adopter of PeerLab, please [sign up](https://nxthdr.dev) and access the [peering dashboard](https://nxthdr.dev/peering) to get started. Don't forget to give us your feedback and suggestions (see [contact](/docs/reference/contact/)).
 

--- a/content/docs/probing/_index.md
+++ b/content/docs/probing/_index.md
@@ -15,7 +15,13 @@ Saimiris is currently in **alpha**. Core functionality is operational and availa
 
 **Alpha Exit Criteria**
 
-Deploy additional probing servers in more geographic locations (objective: >= 10 servers worldwide).
+Before Saimiris exits alpha, we want the platform to be safe to operate unsupervised and at scale:
+
+- **Abuse controls** — destination blocklist filtering (reject probes to blocked targets regardless of TTL), and a maintenance / kill-switch to pause probing during incidents.
+- **User management** — admin endpoints to view and set per-user probe limits, with proper authorization.
+- **Scale** — deploy additional probing servers in more geographic locations (objective: >= 10 servers worldwide).
+
+Per-user quotas, usage statistics, and source-address validation are already in place.
 
 If you need specific vantage points or have capacity requirements, please [contact us](/docs/reference/contact/).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,19 @@
-FROM alpine:latest AS build
+FROM debian:bookworm-slim AS build
 
-RUN apk add --update hugo
+# Pin Hugo (extended). apk's `hugo` floats: it reached 0.160, which removed the
+# .Site.Author field still referenced by the hextra theme's RSS template, breaking
+# every build. Pin to a known-good version until the theme is bumped.
+ARG HUGO_VERSION=0.155.0
+ARG TARGETARCH
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -sSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz" \
+       | tar -xz -C /usr/local/bin hugo \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/hugo
 COPY . .
-RUN hugo 
+RUN hugo
 
 FROM caddy:latest
 


### PR DESCRIPTION
Fills in the previously-"To be defined" exit criteria on both platform status pages, derived from the current state of the code.

**Peering** ([`peering/_index.md`](content/docs/peering/_index.md))
- BGP discipline: max-prefix / import limits, MRAI rate-limiting (≤10 announcements/hour), route-flap damping
- RPKI: inline ROV (`roa_check`) on routes imported from the IXP
- Reload safety: validate generated BIRD config before applying

**Probing** ([`probing/_index.md`](content/docs/probing/_index.md))
- Abuse controls: destination blocklist filtering, maintenance/kill-switch
- User management: admin endpoints to view/set per-user limits
- Keeps the existing ≥10-servers scaling goal

Both keep the **alpha** label — these are the criteria to *reach* beta. The full technical checklists live in roadmap [#41](https://github.com/nxthdr/roadmap/issues/41) and [#29](https://github.com/nxthdr/roadmap/issues/29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)