### PR TITLE
fix: bump hextra theme to v0.12.3, advance Hugo pin to 0.163.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:bookworm-slim AS build
 
-# Pin Hugo (extended). apk's `hugo` floats: it reached 0.160, which removed the
-# .Site.Author field still referenced by the hextra theme's RSS template, breaking
-# every build. Pin to a known-good version until the theme is bumped.
-ARG HUGO_VERSION=0.155.0
+# Pin Hugo (extended) for reproducible builds — apk's `hugo` floats and previously
+# broke the site when it bumped past a theme-incompatible release. Keep this at/above
+# the hextra theme's min_version (see themes/hextra/theme.toml).
+ARG HUGO_VERSION=0.163.2
 ARG TARGETARCH
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \


### PR DESCRIPTION
The real fix for the build breakage worked around in #10.

#10 pinned Hugo to **0.155.0** to keep the old theme building. This addresses the root cause: upstream **hextra migrated its RSS template off the removed `.Site.Author` field** (now `.Site.Params.Author`) when adapting to Hugo's new template system, so the theme works with current Hugo again.

- `themes/hextra`: `v0.9.7-36` → **v0.12.3** (min Hugo 0.146)
- Hugo pin: `0.155.0` → **0.163.2** (current)

**Verification** (built locally with Hugo 0.163.2 + theme v0.12.3):
- Clean build, **no errors and no deprecation warnings** (new theme uses `hugo.Data`)
- **Identical output URL structure** — 40 rendered pages, none added, removed, or relocated vs the old theme

Bonus: v0.12.3 ships an `llms`/`markdown` output format, which is a head start on the "one-page LLM docs" roadmap item whenever we want to enable it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)