### PR TITLE
docs: enable LLM-friendly outputs (llms.txt + per-page markdown)

### DIFF
--- a/content/docs/internals/_index.md
+++ b/content/docs/internals/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Internals
 weight: 6
-prev: /docs/tools/mcp/
+prev: /docs/tools/llms/
 next: /docs/internals/infrastructure/
 ---
 

--- a/content/docs/tools/llms.md
+++ b/content/docs/tools/llms.md
@@ -1,0 +1,26 @@
+---
+title: LLM-Friendly Docs
+weight: 5
+prev: /docs/tools/mcp/
+next: /docs/internals/
+---
+
+This documentation is published in machine-readable formats so that large language models and AI agents can consume it directly, without scraping rendered HTML.
+
+## llms.txt
+
+A single index of the whole documentation is available at [/llms.txt](https://docs.nxthdr.dev/llms.txt), following the [llms.txt convention](https://llmstxt.org/). It lists every page with a short summary and a direct link, giving an agent a compact map of the docs in one request.
+
+## Per-page Markdown
+
+Every page is also available as raw Markdown. Append `.md` to a page's path, or use `index.md` for a section's landing page. For example:
+
+- [/docs/peering/getting-started.md](https://docs.nxthdr.dev/docs/peering/getting-started.md)
+- [/docs/probing/probes.md](https://docs.nxthdr.dev/docs/probing/probes.md)
+- [/docs/peering/index.md](https://docs.nxthdr.dev/docs/peering/index.md) (section landing page)
+
+This gives agents clean, structure-preserving content to ingest instead of HTML.
+
+## Querying the data
+
+To go beyond the documentation and query the open datasets in natural language, see the [MCP Servers](/docs/tools/mcp/) page.

--- a/content/docs/tools/mcp.md
+++ b/content/docs/tools/mcp.md
@@ -1,7 +1,7 @@
 ---
 title: MCP Servers
 weight: 4
-next: /docs/internals/
+next: /docs/tools/llms/
 ---
 
 Since **nxthdr** datasets are stored in ClickHouse, you can use the official MCP server for ClickHouse [mcp-clickhouse](https://github.com/ClickHouse/mcp-clickhouse) to query the data.

--- a/hugo.toml
+++ b/hugo.toml
@@ -11,6 +11,12 @@ theme = "hextra"
   [markup.highlight]
     noClasses = false
 
+# LLM-friendly output (hextra >= 0.12): /llms.txt index + per-page raw markdown.
+[outputs]
+  home = ["HTML", "RSS", "llms"]
+  section = ["HTML", "RSS", "markdown"]
+  page = ["HTML", "markdown"]
+
 
 [[menu.main]]
   name = "Search"


### PR DESCRIPTION
Tests the `llms`/`markdown` output formats that shipped with the hextra v0.12.3 bump (#11). Opting in is a single `[outputs]` block — no new templates needed.

**What it produces** (verified with a local Hugo 0.163.2 build):
- **`/llms.txt`** — a one-page index of the entire site: title, section tree, and a one-line summary + link for every page. This is the [llms.txt standard](https://llmstxt.org/) and the "one-page LLM docs" roadmap idea.
- **Per-page raw markdown** — a clean `.md` twin of all 35 pages (e.g. `/docs/peering/getting-started.md`), ideal for agents/LLMs to ingest without HTML noise.
- RSS preserved on home + section outputs.

**Depends on #11** (the theme bump) — until that merges to `main`, this PR's diff also shows the theme/Hugo-pin commit; it'll reduce to just the `[outputs]` change once #11 lands.

Minor polish available, not included: `/llms.txt`'s `>` description line is blank because the site sets no `params.description` — adding a one-line site description would populate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)