### PR TITLE
docs: remove false RPKI enforcement callout from CLI reference

### DIFF
--- a/content/docs/tools/cli.md
+++ b/content/docs/tools/cli.md
@@ -210,10 +210,6 @@ nxthdr peering prefix rpki disable 2a06:de00:5b::/48
 
 The `prefix list` command also shows the current RPKI status for each lease.
 
-{{< callout type="info" >}}
-RPKI must be re-enabled before revoking a prefix. The platform enforces this for routing stability.
-{{< /callout >}}
-
 ### PeerLab environment
 
 Generate a `.env` file for PeerLab with your ASN and active prefixes:


### PR DESCRIPTION
The callout claimed "RPKI must be re-enabled before revoking a prefix. The platform enforces this for routing stability."

Checked `peerlab-gateway/src/lib.rs` (`revoke_prefix`, ~line 359): the gateway calls `ensure_roa()` as a best-effort before deletion, but the error is only `warn!`-logged — execution always continues to the `delete_prefix_lease` call. No enforcement exists.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)